### PR TITLE
Fix Rails 3 compatibility issues with deprecated RAILS_x methods

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -113,6 +113,10 @@ limitation.  Some of these carriers are include, Mobitel, Etisalat, T-Mobile (Ne
 
 == View Helpers (Rails)
 
+* Include SMSFuHelper in ApplicationHelper (or any controller helper module)
+
+    include SMSFuHelper
+
 * Retrieve a collection of all carriers
 
     <%= carrier_collection %>

--- a/README.rdoc
+++ b/README.rdoc
@@ -113,7 +113,7 @@ limitation.  Some of these carriers are include, Mobitel, Etisalat, T-Mobile (Ne
 
 == View Helpers (Rails)
 
-* Include SMSFuHelper in ApplicationHelper (or any controller helper module)
+* Include SMSFuHelper in controller or helper module
 
     include SMSFuHelper
 

--- a/lib/sms_fu/sms_fu.rb
+++ b/lib/sms_fu/sms_fu.rb
@@ -99,8 +99,11 @@ module SMSFu
     end  
 
     def template_directory
-      directory = defined?(Rails) ? "#{RAILS_ROOT}/config" : "#{File.dirname(__FILE__)}/../../templates"
-      if (defined?(Rails) && Rails.env == 'test') || (defined?(RAILS_ENV) && RAILS_ENV == 'test)')
+      rails_root = defined?(Rails) ? Rails.root : (defined?(RAILS_ROOT) ? RAILS_ROOT : nil)
+      env = defined?(Rails) ? Rails.env : (defined?(RAILS_ENV) ? RAILS_ENV : nil)
+
+      directory = !rails_root.nil? ? "#{rails_root}/config" : "#{File.dirname(__FILE__)}/../../templates"
+      if env == 'test'
         "#{File.dirname(__FILE__)}/../../templates"
       else
         directory


### PR DESCRIPTION
Refactored the logic for determining the template directory to work with Rails 3.   The README was updated as well to document that SMSFuHelper must be included to use the view helpers.
